### PR TITLE
Add voice-based agent skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# agent-protocol
+# Voice Agent
+
+This project provides a basic template for a voice-driven AI assistant.
+It contains a Python backend powered by FastAPI and a React Native frontend.
+The mobile app listens for speech, sends it to the backend and speaks the
+response back without any button presses.
+
+## Structure
+
+- `backend` – FastAPI server with simple chat and text-to-speech endpoints.
+- `frontend` – React Native (Expo) app that interacts with the backend using
+  voice.
+
+## Getting Started
+
+1. Start the backend:
+
+   ```bash
+   cd backend
+   pip install -r requirements.txt
+   uvicorn app:app --reload
+   ```
+
+2. Run the mobile app:
+
+   ```bash
+   cd frontend
+   npm install
+   npx expo start
+   ```
+
+With both running you can talk to the app and receive spoken replies.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,15 @@
+# Backend
+
+This is a simple FastAPI server that exposes two endpoints:
+
+- `/chat` receives a piece of text and echoes back a response. Replace the logic with an AI model (e.g. OpenAI) to create a real agent.
+- `/tts` converts text to speech using `pyttsx3` and returns an MP3 file.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+uvicorn app:app --reload
+```
+
+The server listens on `http://localhost:8000` by default.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,33 @@
+from fastapi import FastAPI, UploadFile, File, Response
+from fastapi.middleware.cors import CORSMiddleware
+import openai
+import io
+import pyttsx3
+from pydantic import BaseModel
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=['*'],
+    allow_credentials=True,
+    allow_methods=['*'],
+    allow_headers=['*'],
+)
+
+class ChatRequest(BaseModel):
+    text: str
+
+@app.post('/chat')
+async def chat(request: ChatRequest):
+    # Simple echo chatbot; replace with openai.ChatCompletion for actual AI
+    response_text = f"You said: {request.text}"
+    return {"response": response_text}
+
+@app.post('/tts')
+async def tts(request: ChatRequest):
+    engine = pyttsx3.init()
+    engine.save_to_file(request.text, 'response.mp3')
+    engine.runAndWait()
+    audio_bytes = open('response.mp3', 'rb').read()
+    return Response(content=audio_bytes, media_type='audio/mpeg')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+openai
+pyttsx3

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import Voice from '@react-native-voice/voice';
+import * as Speech from 'expo-speech';
+import axios from 'axios';
+
+export default function App() {
+  const [transcript, setTranscript] = useState('');
+
+  useEffect(() => {
+    Voice.onSpeechResults = onSpeechResults;
+    startListening();
+    return () => {
+      Voice.destroy().then(Voice.removeAllListeners);
+    };
+  }, []);
+
+  const onSpeechResults = (e) => {
+    const text = e.value[0];
+    setTranscript(text);
+    axios.post('http://localhost:8000/chat', { text })
+      .then(res => {
+        const response = res.data.response;
+        Speech.speak(response, { onDone: startListening });
+      })
+      .catch(err => console.error(err));
+  };
+
+  const startListening = () => {
+    Voice.start('en-US');
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text>{transcript}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,16 @@
+# Frontend
+
+A minimal React Native app that interacts with the backend entirely through voice.
+When the app loads it starts listening for speech, sends transcribed text to the
+backend and speaks the response.
+
+## Setup
+
+This project uses Expo for convenience. Install dependencies and start the app:
+
+```bash
+npm install
+npx expo start
+```
+
+Make sure the backend is running on `http://localhost:8000`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "voice-agent",
+  "version": "0.1.0",
+  "main": "App.js",
+  "dependencies": {
+    "axios": "^1.4.0",
+    "@react-native-voice/voice": "^3.2.0",
+    "expo": "~48.0.0",
+    "expo-speech": "~11.1.0",
+    "react": "18.2.0",
+    "react-native": "0.71.8"
+  }
+}


### PR DESCRIPTION
## Summary
- create Python FastAPI backend with chat and TTS endpoints
- add React Native frontend with voice recognition and TTS
- document how to run backend and frontend

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6840587367388321866e4d68c2321d85